### PR TITLE
fix: update documentation link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Project Info
 ------------
 
 - Homepage: `https://pypi.python.org/pypi/PyDrive <https://pypi.python.org/pypi/PyDrive>`_
-- Documentation: `Official documentation on GitHub pages <https://gsuitedevs.github.io/PyDrive/docs/build/html/index.html>`_
+- Documentation: `Official documentation on GitHub pages <https://googleworkspace.github.io/PyDrive/docs/build/html/index.html>`_
 - GitHub: `https://github.com/gsuitedevs/PyDrive <https://github.com/gsuitedevs/PyDrive>`_
 
 Features of PyDrive


### PR DESCRIPTION
The URL has changed from gsuitedevs.github.io to googleworkspace.github.io

Fixes #125 and #203