### PR TITLE
gsuitedevs -> googleworkspace

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Project Info
 
 - Homepage: `https://pypi.python.org/pypi/PyDrive <https://pypi.python.org/pypi/PyDrive>`_
 - Documentation: `Official documentation on GitHub pages <https://googleworkspace.github.io/PyDrive/docs/build/html/index.html>`_
-- GitHub: `https://github.com/gsuitedevs/PyDrive <https://github.com/gsuitedevs/PyDrive>`_
+- GitHub: `https://github.com/googleworkspace/PyDrive <https://github.com/googleworkspace/PyDrive>`_
 
 Features of PyDrive
 -------------------
@@ -34,7 +34,7 @@ To install the current development version from GitHub, use:
 
 ::
 
-    $  pip install git+https://github.com/gsuitedevs/PyDrive.git#egg=PyDrive
+    $  pip install git+https://github.com/googleworkspace/PyDrive.git#egg=PyDrive
 
 OAuth made easy
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,8 +12,8 @@ Project Info
 ============
 
 - Homepage: `https://pypi.python.org/pypi/PyDrive <https://pypi.python.org/pypi/PyDrive>`_
-- Documentation: `Official documentation on GitHub pages <https://gsuitedevs.github.io/PyDrive/docs/build/html/index.html>`_
-- Github: `https://github.com/gsuitedevs/PyDrive <https://github.com/gsuitedevs/PyDrive>`_
+- Documentation: `Official documentation on GitHub pages <https://googleworkspace.github.io/PyDrive/docs/build/html/index.html>`_
+- Github: `https://github.com/googleworkspace/PyDrive <https://github.com/googleworkspace/PyDrive>`_
 
 How to install
 ==============
@@ -28,7 +28,7 @@ To install the current development version from GitHub, use:
 
 ::
 
-    $ pip install git+https://github.com/gsuitedevs/PyDrive.git#egg=PyDrive
+    $ pip install git+https://github.com/googleworkspace/PyDrive.git#egg=PyDrive
 
 Table of Contents
 =================

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     maintainer='Robin Nabel',
     maintainer_email='rnabel@ucdavis.edu',
     packages=['pydrive', 'pydrive.test'],
-    url='https://github.com/gsuitedevs/PyDrive',
+    url='https://github.com/googleworkspace/PyDrive',
     license='LICENSE',
     description='Google Drive API made easy.',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
Change a few other links to googleworkspace. https://pypi.org/project/PyDrive/ is outdated too (don't know how to update it there).

PS.: just checked the issues and figured out that it is not actively maintained at the moment, I guess. I gonna try https://github.com/iterative/PyDrive2 then :)