### PR TITLE
fill in license metadata in setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,15 @@ setup(
     maintainer_email='rnabel@ucdavis.edu',
     packages=['pydrive', 'pydrive.test'],
     url='https://github.com/googleworkspace/PyDrive',
-    license='LICENSE',
+    license='Apache 2.0',
     description='Google Drive API made easy.',
     long_description=open('README.rst').read(),
     install_requires=[
         "google-api-python-client >= 1.2",
         "oauth2client >= 4.0.0",
         "PyYAML >= 3.0",
+    ],
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
     ],
 )


### PR DESCRIPTION
I was doing an internal audit of license compliance and discovered that this package doesn't properly fill in the license metadata in its setup.py. Reading the `LICENSE` file, it appears to be standard Apache 2.0, so I filled that in appropriately in the license field and the trove classifier. This matches how other Google projects (e.g., everything from googleapis) represent their license status.